### PR TITLE
feat: append nvme_core.io_timeout to kernel command line

### DIFF
--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -1,3 +1,15 @@
+kernel-cmdline:
+  allow:
+    - nvme_core.io_timeout=*
+
+defaults:
+  system:
+    kernel-cmdline:
+      append:
+        # Extended the IO timeout on NVME storage to its maximum value
+        # see http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
+        nvme_core.io_timeout=4294967295
+
 volumes:
   pc:
     schema: gpt

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -1,3 +1,15 @@
+kernel-cmdline:
+  allow:
+    - nvme_core.io_timeout=*
+
+defaults:
+  system:
+    kernel-cmdline:
+      append:
+        # Extended the IO timeout on NVME storage to its maximum value
+        # see http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
+        nvme_core.io_timeout=4294967295
+
 volumes:
   pc:
     # bootloader configuration is shipped and managed by snapd


### PR DESCRIPTION
That's the recommended value according to AWS[0] and that's what the default is on Classic Ubuntu images for AWS.

Refs:
- [0] https://docs.aws.amazon.com/ebs/latest/userguide/timeout-nvme-ebs-volumes.html