### PR TITLE
feat: set default nvme_core.io_timeout on dangerous kernel cmd

### DIFF
--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -10,6 +10,12 @@ defaults:
         # see http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
         nvme_core.io_timeout=4294967295
 
+    kernel-dangerous-cmdline:
+      append:
+        # Extended the IO timeout on NVME storage to its maximum value
+        # see http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
+        nvme_core.io_timeout=4294967295
+
 volumes:
   pc:
     schema: gpt

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -10,6 +10,12 @@ defaults:
         # see http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
         nvme_core.io_timeout=4294967295
 
+    kernel-dangerous-cmdline:
+      append:
+        # Extended the IO timeout on NVME storage to its maximum value
+        # see http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
+        nvme_core.io_timeout=4294967295
+
 volumes:
   pc:
     # bootloader configuration is shipped and managed by snapd


### PR DESCRIPTION
Similar to e1192bb16b12a8ff5 but now for the kernel-dangerous-cmdline.