### PR TITLE
fix: use correct yaml syntax for kernel parameters

### DIFF
--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -4,11 +4,11 @@ kernel-cmdline:
 
 defaults:
   system:
-    kernel-cmdline:
-      append:
+    system:
+      kernel:
         # Extended the IO timeout on NVME storage to its maximum value
         # see http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
-        nvme_core.io_timeout=4294967295
+        cmdline-append: nvme_core.io_timeout=4294967295
 
 volumes:
   pc:

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -4,11 +4,11 @@ kernel-cmdline:
 
 defaults:
   system:
-    kernel-cmdline:
-      append:
+    system:
+      kernel:
         # Extended the IO timeout on NVME storage to its maximum value
         # see http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
-        nvme_core.io_timeout=4294967295
+        cmdline-append: nvme_core.io_timeout=4294967295
 
 volumes:
   pc:


### PR DESCRIPTION
The kernel-cmdline.append key needs to be a list, not a hashtable.