### PR TITLE
fix: drop connections from gadgets

### DIFF
--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -10,11 +10,6 @@ defaults:
         # see http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
         cmdline-append: nvme_core.io_timeout=4294967295
 
-# auto-connect aws-gadget plugs
-connections:
-  - plug: mfDoEMcyOtXRpzrpIFuNDkJ2oAQWOquG:install-mode-etc-sysctl-d-50-aws-gadget-conf
-    slot: system:system-files
-
 volumes:
   pc:
     schema: gpt

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -10,11 +10,6 @@ defaults:
         # see http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
         cmdline-append: nvme_core.io_timeout=4294967295
 
-# auto-connect aws-gadget plugs
-connections:
-  - plug: mfDoEMcyOtXRpzrpIFuNDkJ2oAQWOquG:install-mode-etc-sysctl-d-50-aws-gadget-conf
-    slot: system:system-files
-
 volumes:
   pc:
     # bootloader configuration is shipped and managed by snapd

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,11 @@
+#!/bin/sh -ux
+
+mkdir -p /etc/sysctl.d/
+
+# Increase ARP table size (see LP:#2060001)
+# Increase maximum number of connection (see LP:#2063538)
+cat << EOF > "/etc/sysctl.d/50-aws-gadget.conf"
+net.ipv4.neigh.default.gc_thresh2=15360
+net.ipv4.neigh.default.gc_thresh3=16384
+net.netfilter.nf_conntrack_max=1048576
+EOF

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,6 +28,11 @@ plugs:
     interface: system-files
     write:
       - /etc/sysctl.d/50-aws-gadget.conf
+  load-nf-conntrack:
+    interface: kernel-module-load
+    modules:
+      - name: nf_conntrack
+        load: on-boot
 
 hooks:
   install-device:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -24,11 +24,19 @@ plugs:
     interface: system-files
     write:
       - /run/mnt/ubuntu-data/system-data/_writable_defaults/etc/sysctl.d/50-aws-gadget.conf
+  etc-sysctl-d-50-aws-gadget-conf:
+    interface: system-files
+    write:
+      - /etc/sysctl.d/50-aws-gadget.conf
 
 hooks:
   install-device:
     plugs:
       - install-mode-etc-sysctl-d-50-aws-gadget-conf
+  post-refresh:
+    plugs:
+      - etc-sysctl-d-50-aws-gadget-conf
+
   prepare-device:
     environment:
       # If you are forking and building your own gadget:


### PR DESCRIPTION
There will be a store-request to have the auto-connections. That's the preferred way.
Also connections: from the gadget.yaml are only parsed on first boot. So if the gadget gets updated (and connections: get updated), those updates would not be applied.