### PR TITLE
feat: set custom MOTD via cloud-init

### DIFF
--- a/cloud.conf
+++ b/cloud.conf
@@ -2,3 +2,25 @@
 datasource:
   Ec2:
     apply_full_imds_network_config: true
+
+runcmd:
+  - [ bash, -lc, "mkdir -p /etc/motd.d && ln -sf /dev/null /etc/motd.d/50-default" ]
+
+write_files:
+  - path: /etc/motd.d/99-custom-aws
+    owner: root:root
+    permissions: "0644"
+    defer: true
+    content: |
+      Welcome to Ubuntu Core 24
+
+      * Documentation: https://ubuntu.com/core/docs
+
+      This is a pre-built Ubuntu Core image. Pre-built images are ideal for
+      exploration as you develop your own custom Ubuntu Core image.
+
+      To learn how to create your custom Ubuntu Core image, see our guide:
+
+      * Getting Started: https://ubuntu.com/core/docs/get-started
+
+      * First steps: https://ubuntu.com/core/docs/first-steps


### PR DESCRIPTION
Current MOTD is intended for devices, not cloud images.