### PR TITLE
fix: add build-base to snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,6 +2,7 @@ name: aws-gadget
 adopt-info: cloud-init
 type: gadget
 base: core26
+build-base: devel
 summary: AWS gadget for EC2 instances
 description: |
     This gadget enables AWS EC2 instances to run Ubuntu Core


### PR DESCRIPTION
build-base is required with unstable bases

Fixes:
```
Bad snapcraft.yaml content:
- field 'build-base' required in 'has-base.core26' configuration
```